### PR TITLE
Don't make a TreeGrid of a TreeGrid

### DIFF
--- a/vol_pypykatz.py
+++ b/vol_pypykatz.py
@@ -38,18 +38,4 @@ class pypykatz(interfaces.plugins.PluginInterface):
         ]
 
     def run(self):
-        return renderers.TreeGrid(
-            [
-                ("Credential Type", str),
-                ("Domain Name", str),
-                ("Username", str),
-                ("NThash", str),
-                ("LMHash", str),
-                ("SHAHash", str),
-                ("masterkey", str),
-                ("masterkey (sha1)", str),
-                ("key_guid", str),
-                ("password", str),
-            ],
-            pparser.go_volatility3(self),
-        )
+        return pparser.go_volatility3(self)


### PR DESCRIPTION
A TreeGrid is already returned in [pypykatz/pypykatz.py:221](https://github.com/skelsec/pypykatz/blob/dd129ff36e00593d1340776b517f7e749ad8d314/pypykatz/pypykatz.py#L221)