### PR TITLE
Updating pypykatz volatility3 plugin to account for framework version 2

### DIFF
--- a/vol_pypykatz.py
+++ b/vol_pypykatz.py
@@ -8,7 +8,7 @@
 import logging
 from typing import List
 
-from volatility3.framework import interfaces, renderers
+from volatility3.framework import interfaces, renderers, constants
 from volatility3.framework.configuration import requirements
 from volatility3.plugins.windows import pslist
 
@@ -16,40 +16,39 @@ from pypykatz.pypykatz import pypykatz as pparser
 
 vollog = logging.getLogger(__name__)
 
+framework_version = constants.VERSION_MAJOR
 
 class pypykatz(interfaces.plugins.PluginInterface):
-
-    _required_framework_version = (1, 0, 0)
+    _required_framework_version = (framework_version, 0, 0)
 
     @classmethod
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
-        return [
-            requirements.TranslationLayerRequirement(
-                name="primary",
-                description="Memory layer for the kernel",
-                architectures=["Intel32", "Intel64"],
-            ),
-            requirements.SymbolTableRequirement(
-                name="nt_symbols", description="Windows kernel symbols"
-            ),
-            requirements.PluginRequirement(
-                name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
-            ),
-        ]
+        reqs = []
+        if framework_version == 1:
+            kernel_layer_name = 'primary'
+            reqs = [requirements.TranslationLayerRequirement(name = kernel_layer_name,
+                                                                    description = 'Memory layer for the kernel',
+                                                                    architectures = ["Intel32", "Intel64"]),
+                        requirements.SymbolTableRequirement(name = "nt_symbols",
+                                                            description = "Windows kernel symbols"),
+                        requirements.PluginRequirement(
+                            name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                        ),
+                    ]
+        elif framework_version == 2:
+            kernel_layer_name = 'kernel'
+            reqs = [requirements.ModuleRequirement(name = kernel_layer_name,
+                                                        description = 'Windows kernel',
+                                                        architectures = ["Intel32", "Intel64"]),
+                    requirements.PluginRequirement(
+                        name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                    ),
+                    ]
+        else:
+            # The highest major version we currently support is 2.
+            raise RuntimeError(f"Framework interface version {framework_version} is  currently not supported.")
+
+        return reqs
 
     def run(self):
-        return renderers.TreeGrid(
-            [
-                ("Credential Type", str),
-                ("Domain Name", str),
-                ("Username", str),
-                ("NThash", str),
-                ("LMHash", str),
-                ("SHAHash", str),
-                ("masterkey", str),
-                ("masterkey (sha1)", str),
-                ("key_guid", str),
-                ("password", str),
-            ],
-            pparser.go_volatility3(self),
-        )
+        return pparser.go_volatility3(self, framework_version)


### PR DESCRIPTION
This PR accompanies the [PR in pypykatz](https://github.com/skelsec/pypykatz/pull/151), which updates the volreader. Both PRs together account for Volatility3's framework version 2.

Test output ([image file](https://drive.google.com/drive/folders/1E-i2RTUBXBGUd_Xz0k67kFOpHcr6WX8J)):
```
./vol.py -f ~/Downloads/memdump.mem windows.vol_pypykatz.pypykatz 
Volatility 3 Framework 2.7.0
Progress:  100.00		PDB scanning finished                                                                                              
credtype	domainname	username	NThash	LMHash	SHAHash	masterkey	masterkey(sha1)	key_guid	password

msv	DESKTOP-AP0UE04	CTF	e7a0f109cbb4d07339c8b25f45bf0356		6c6930a0c1f64803fdf335521db91257dfe87c99				
dpapi						6a9749a19a4baa8dd8354402e2f12446d34c914d36d05836e0750544b14de1d60584217cb0e873f312f935fc8d90c407caff61376d940163d170592b4467f509	841961bf9d86e20e4ed78e10f36976285a92569e	755a57ae-d74a-4da0-a1fd-31f72d598dcb	
msv	DESKTOP-AP0UE04	CTF	e7a0f109cbb4d07339c8b25f45bf0356		6c6930a0c1f64803fdf335521db91257dfe87c99				
dpapi						f76d0338632d49a19107aadc56c3727a63b36125cdbdea9b500239bad346b1b621dc4274b200fcae37b1abf547b8202b540afd8bac67bb0cfad0099df754661b	4a86f72887085cce09c7b7442f7c53297b83d472	232b0b55-bd1b-4587-a378-b22d25e29745	
dpapi						8346e3286cc9f95a765b61bc5b1480e076fb88a1b26361fb87651ad6d861c17c91b4853e225078eda2f86dbca390365fe63ca488440c4d2ae5d380248aaf92e2	253a5372ab7a2ff5766a12eff57c5d48883e7cfe	9119ec06-277e-4462-8497-d0af1d162111	
dpapi						4b0a18fe08d6b89d45c820104688aa2cb9427f68b8fe7fab5151eb25e3e09a7f214ddd3ad21589ecb22586f068b2631477e04a08fa2921f768bb0ab9581220f1	5a6f029851f531910cb02befe27c51dfb992da14	c355eb5d-74c7-4240-af99-1875be257f68	
dpapi						4f88e7c3cc9774097556b23148539362bbee4f97a9ae23519958e4501af659f8c38af7e13da4d66fa06339eaee642323875f75b329c798ae85556722f8fc56a0	51fac63b37d20d5c75e12cad3fae131c61d1640c	1ce78138-2475-4faf-a061-336531275653
```