### PR TITLE
Fix Requirements and plugin version

### DIFF
--- a/vol_pypykatz.py
+++ b/vol_pypykatz.py
@@ -18,6 +18,7 @@ vollog = logging.getLogger(__name__)
 
 framework_version = constants.VERSION_MAJOR
 
+
 class pypykatz(interfaces.plugins.PluginInterface):
     _required_framework_version = (framework_version, 0, 0)
 
@@ -25,28 +26,37 @@ class pypykatz(interfaces.plugins.PluginInterface):
     def get_requirements(cls) -> List[interfaces.configuration.RequirementInterface]:
         reqs = []
         if framework_version == 1:
-            kernel_layer_name = 'primary'
-            reqs = [requirements.TranslationLayerRequirement(name = kernel_layer_name,
-                                                                    description = 'Memory layer for the kernel',
-                                                                    architectures = ["Intel32", "Intel64"]),
-                        requirements.SymbolTableRequirement(name = "nt_symbols",
-                                                            description = "Windows kernel symbols"),
-                        requirements.PluginRequirement(
-                            name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
-                        ),
-                    ]
+            kernel_layer_name = "primary"
+            reqs = [
+                requirements.TranslationLayerRequirement(
+                    name=kernel_layer_name,
+                    description="Memory layer for the kernel",
+                    architectures=["Intel32", "Intel64"],
+                ),
+                requirements.SymbolTableRequirement(
+                    name="nt_symbols", description="Windows kernel symbols"
+                ),
+                requirements.PluginRequirement(
+                    name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
+                ),
+            ]
         elif framework_version == 2:
-            kernel_layer_name = 'kernel'
-            reqs = [requirements.ModuleRequirement(name = kernel_layer_name,
-                                                        description = 'Windows kernel',
-                                                        architectures = ["Intel32", "Intel64"]),
-                    requirements.PluginRequirement(
-                        name="pslist", plugin=pslist.PsList, version=(2, 0, 0)
-                    ),
-                    ]
+            kernel_layer_name = "kernel"
+            reqs = [
+                requirements.ModuleRequirement(
+                    name=kernel_layer_name,
+                    description="Windows kernel",
+                    architectures=["Intel32", "Intel64"],
+                ),
+                requirements.VersionRequirement(
+                    name="pslist", component=pslist.PsList, version=(3, 0, 0)
+                ),
+            ]
         else:
             # The highest major version we currently support is 2.
-            raise RuntimeError(f"Framework interface version {framework_version} is  currently not supported.")
+            raise RuntimeError(
+                f"Framework interface version {framework_version} is  currently not supported."
+            )
 
         return reqs
 


### PR DESCRIPTION
The plugin counterpart to [PR 177](https://github.com/skelsec/pypykatz/pull/177).

Update the version requirements that prevented the plugin from running and switch to `VersionRequirement`.

`PluginRequirement` is now [deprecated](https://github.com/volatilityfoundation/volatility3/pull/1821) in favour of `VersionRequirement`.

